### PR TITLE
CA-260671: do not leak file descriptors

### DIFF
--- a/src/helpers.ml
+++ b/src/helpers.ml
@@ -16,23 +16,23 @@
 
 let split str n =
   let l = String.length str in
-  if n>l 
-  then (str,"") 
+  if n>l
+  then (str,"")
   else (String.sub str 0 n, String.sub str n (l-n))
 
 let break pred str =
   let l = String.length str in
-  let rec inner = function 
+  let rec inner = function
     | 0 -> (str,"")
-    | n -> 
-      if pred str.[l-n] 
+    | n ->
+      if pred str.[l-n]
       then split str (l-n)
       else inner (n-1)
   in inner l
 
-let str_drop_while pred str = 
-  let l = String.length str in 
-  let rec inner = function 
+let str_drop_while pred str =
+  let l = String.length str in
+  let rec inner = function
     | 0 -> ""
     | n ->
       if pred str.[l-n]

--- a/src/iteratees.ml
+++ b/src/iteratees.ml
@@ -168,7 +168,7 @@ module Iteratee (IO : Monad) = struct
     let rec step st = match st with
       | Chunk s ->
         let news = str_drop_while pred s in
-        if news="" 
+        if news=""
         then ie_contM step (Chunk "")
         else ie_doneM () (Chunk news)
       | Eof _ ->
@@ -185,13 +185,13 @@ module Iteratee (IO : Monad) = struct
 
   let apply f =
     let rec step st = match st with
-      | Chunk s -> 
+      | Chunk s ->
         f s;
         ie_contM step (Chunk "")
       | Eof _ -> ie_doneM () st
     in IE_cont (None, step)
 
-  let liftI m = 
+  let liftI m =
     let step st i =
       match i with
       | IE_cont (None, k) -> k st

--- a/src/iteratees.mli
+++ b/src/iteratees.mli
@@ -36,9 +36,9 @@ module Iteratee :
   sig
     (** The type t describes the current state of the iteratee.
         It's either 'Done', in which case it's got some sort of
-        value, or it's in the 'Cont' state, which mean's it 
-        hasn't finished processing - in this case it may be in 
-        an error state, or it may be awaiting more input. 
+        value, or it's in the 'Cont' state, which mean's it
+        hasn't finished processing - in this case it may be in
+        an error state, or it may be awaiting more input.
     *)
 
     type 'a t =
@@ -96,7 +96,7 @@ module Iteratee :
     (** read_int32 - reads an int32 from the stream (bigendian byte order) *)
     val read_int32 : int32 t
 
-    (** drop_while - iteratee that drops characters from the stream while they 
+    (** drop_while - iteratee that drops characters from the stream while they
         satisfy the supplied predicate *)
     val drop_while : (char -> bool) -> unit t
 
@@ -134,11 +134,11 @@ module Iteratee :
         iteratee *)
     type 'a enumeratee = 'a t -> 'a t t
 
-    (** take - takes exactly n characters from the input stream and applies them to 
+    (** take - takes exactly n characters from the input stream and applies them to
         the inner stream *)
     val take : int -> 'a t -> 'a t t
 
-    (** stream_printer - given a name and an iteratee i, returns an iteratee that 
+    (** stream_printer - given a name and an iteratee i, returns an iteratee that
         will print the chunks supplied before handing them off to the iteratee *)
     val stream_printer : string -> 'a t -> 'a t t
 

--- a/src/lwt_support.ml
+++ b/src/lwt_support.ml
@@ -12,7 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open Iteratees 
+open Iteratees
 
 type 'a t = 'a Iteratee(Lwt).t =
   | IE_done of 'a
@@ -31,22 +31,22 @@ let lwt_fd_enumerator fd =
   let blocksize = 1024 in
   let str = Bytes.create blocksize in
   let get_str n =
-    if n=0 
-    then (Eof None) 
+    if n=0
+    then (Eof None)
     else (Chunk (String.sub str 0 n))
   in
   let rec go = function
-    | IE_cont (None,x) -> 
+    | IE_cont (None,x) ->
       Lwt_unix.read fd str 0 blocksize >>= fun n ->
-      x (get_str n)                    >>= fun x -> 
+      x (get_str n)                    >>= fun x ->
       Lwt.return (fst x)               >>= fun x ->
       go x
-    | x -> Lwt.return x 
-  in go 
+    | x -> Lwt.return x
+  in go
 
 let lwt_enumerator file iter =
   let (>>=) = Lwt.bind in
-  Lwt_unix.openfile file [Lwt_unix.O_RDONLY] 0o777 >>= fun fd -> 
+  Lwt_unix.openfile file [Lwt_unix.O_RDONLY] 0o777 >>= fun fd ->
   lwt_fd_enumerator fd iter
 
 exception Host_not_found of string

--- a/src/test.ml
+++ b/src/test.ml
@@ -21,7 +21,7 @@ module NoOpMonad = struct
 end
 
 module StringMonad = struct
-  type 'a t = 
+  type 'a t =
     { data : 'a;
       str : string }
   let return a = { data=a; str=""; }
@@ -29,7 +29,7 @@ module StringMonad = struct
     let newstr = f x.data in
     {newstr with str = x.str ^ newstr.str}
 
-  let strwr x = 
+  let strwr x =
     { data=(); str=x }
   let getstr x = x.str
   let getdata x = x.data

--- a/src/websockets.ml
+++ b/src/websockets.ml
@@ -28,7 +28,7 @@ module Wsprotocol (IO : Iteratees.Monad) = struct
     let result = Buffer.create (String.length s) in
     for i = 0 to String.length s - 1 do
       if (String.unsafe_get s i >= '\000' && String.unsafe_get s i <= '\032')
-         || String.unsafe_get s i = '\127'
+      || String.unsafe_get s i = '\127'
       then ()
       else Buffer.add_char result (String.unsafe_get s i)
     done;

--- a/src/websockets.mli
+++ b/src/websockets.mli
@@ -14,7 +14,7 @@
 
 module Wsprotocol :
   functor (IO : Iteratees.Monad) ->
-  sig 
+  sig
     type 'a t = 'a Iteratees.Iteratee(IO).t
 
     (** Exposing the writer from the IO Iteratee *)

--- a/src/wsproxy.ml
+++ b/src/wsproxy.ml
@@ -47,14 +47,13 @@ let start path handler =
          List.iter (fun fd -> Printf.printf "got fd: %d\n%!" (Obj.magic fd)) newfds;
          Printf.printf "About to fixup the fd\n%!";
          Lwt.catch
-          (fun () ->
-            ignore(handler (Lwt_unix.of_unix_file_descr (List.hd newfds)) msg);
-            Lwt.return ()
-          )
-          (fun e ->
-            List.iter (fun fd -> try Unix.close fd with _ -> ()) newfds;
-            Printf.printf "Caught exception: %s\n" (Printexc.to_string e);
-            Lwt.return ()) >>= fun _ ->
+           (fun () ->
+              ignore(handler (Lwt_unix.of_unix_file_descr (List.hd newfds)) msg);
+              Lwt.return ())
+           (fun e ->
+              List.iter (fun fd -> try Unix.close fd with _ -> ()) newfds;
+              Printf.printf "Caught exception: %s\n" (Printexc.to_string e);
+              Lwt.return ()) >>= fun _ ->
          loop ()
       )
       (fun e ->
@@ -87,15 +86,15 @@ let proxy (fd : Lwt_unix.file_descr) protocol _ty localport =
     Lwt.return () in
   Lwt.catch
     (fun () ->
-      Lwt.join [thread1; thread2] >>= fun () -> 
-      Lwt_unix.close fd >>= fun () ->
-      Lwt_unix.close localfd)
+       Lwt.join [thread1; thread2] >>= fun () -> 
+       Lwt_unix.close fd >>= fun () ->
+       Lwt_unix.close localfd)
     (fun _ ->
-      ignore_exn (fun () -> Lwt_unix.close fd) () >>= fun () -> 
-      ignore_exn (fun () -> Lwt_unix.close localfd) ())
+       ignore_exn (fun () -> Lwt_unix.close fd) () >>= fun () -> 
+       ignore_exn (fun () -> Lwt_unix.close localfd) ())
   >>= fun () -> 
-    Printf.printf "FD closed: %b %b\n" Lwt_unix.(state fd == Closed) Lwt_unix.(state localfd == Closed)
-    |> Lwt.return
+  Printf.printf "FD closed: %b %b\n" Lwt_unix.(state fd == Closed) Lwt_unix.(state localfd == Closed)
+  |> Lwt.return
 
 let handler sock msg =
   Lwt_io.printf "Got msg: %s\n" msg >>= fun _ ->

--- a/src/wsproxy.ml
+++ b/src/wsproxy.ml
@@ -48,7 +48,9 @@ let start path handler =
          Printf.printf "About to fixup the fd\n%!";
          Lwt.catch
            (fun () ->
-              ignore(handler (Lwt_unix.of_unix_file_descr (List.hd newfds)) msg);
+              let fdh :: fdt = newfds in
+              ignore(handler (Lwt_unix.of_unix_file_descr fdh) msg);
+              List.iter (fun fd -> try Unix.close fd with _ -> ()) fdt;
               Lwt.return ())
            (fun e ->
               List.iter (fun fd -> try Unix.close fd with _ -> ()) newfds;

--- a/src/wsproxy.ml
+++ b/src/wsproxy.ml
@@ -13,7 +13,7 @@
  *)
 
 
-let get_dir_path () = Printf.sprintf "/var/xapi/" 
+let get_dir_path () = Printf.sprintf "/var/xapi/"
 
 let ignore_exn t () = Lwt.catch t (fun _ -> Lwt.return_unit)
 
@@ -24,22 +24,22 @@ let start path handler =
   let dir_path = get_dir_path () in
   let fd_sock_path = Printf.sprintf "%s%s" dir_path path in
   let fd_sock = Lwt_unix.socket Unix.PF_UNIX Unix.SOCK_STREAM 0 in
-  Lwt.catch 
-    (fun () -> Lwt_unix.unlink fd_sock_path) 
+  Lwt.catch
+    (fun () -> Lwt_unix.unlink fd_sock_path)
     (fun _ -> Lwt.return ()) >>= fun () ->
   let () = Lwt_unix.bind fd_sock (Unix.ADDR_UNIX fd_sock_path) in
   let () = Lwt_unix.listen fd_sock 5 in
 
   let rec loop () =
-    Lwt.catch 
+    Lwt.catch
       (fun () ->
          Lwt_unix.accept fd_sock >>= fun (fd_sock2,_) ->
          let buffer = String.make 16384 '\000' in
          let iov = Lwt_unix.io_vector ~buffer ~offset:0 ~length:16384 in
          (
-           try Lwt_unix.recv_msg ~socket:fd_sock2 ~io_vectors:[iov] 
+           try Lwt_unix.recv_msg ~socket:fd_sock2 ~io_vectors:[iov]
            with _ ->
-             Lwt_unix.close fd_sock2 >>= fun () -> 
+             Lwt_unix.close fd_sock2 >>= fun () ->
              Lwt.return (0,[])
          ) >>= fun (len,newfds) ->
          let msg = String.sub buffer 0 len in
@@ -68,31 +68,31 @@ let proxy (fd : Lwt_unix.file_descr) protocol _ty localport =
   let open Lwt_support in
   let (frame,unframe) =
     match protocol with
-    | "hixie76" -> 
-      Printf.printf "old-style\n%!"; 
+    | "hixie76" ->
+      Printf.printf "old-style\n%!";
       (wsframe_old, wsunframe_old)
-    | "hybi10" -> 
+    | "hybi10" ->
       Printf.printf "new-style\n%!";
       (wsframe, wsunframe)
-    | _ -> 
+    | _ ->
       Printf.printf "unknown\n%!";
       (wsframe,wsunframe)
   in
   let (realframe,realunframe) = (frame, unframe) in
-  open_connection_fd "localhost" localport >>= fun localfd -> 
-  let thread1 = lwt_fd_enumerator localfd (realframe (writer (really_write fd) "thread1")) >>= fun _ -> 
+  open_connection_fd "localhost" localport >>= fun localfd ->
+  let thread1 = lwt_fd_enumerator localfd (realframe (writer (really_write fd) "thread1")) >>= fun _ ->
     Lwt.return () in
-  let thread2 = lwt_fd_enumerator fd (realunframe (writer (really_write localfd) "thread2")) >>= fun _ -> 
+  let thread2 = lwt_fd_enumerator fd (realunframe (writer (really_write localfd) "thread2")) >>= fun _ ->
     Lwt.return () in
   Lwt.catch
     (fun () ->
-       Lwt.join [thread1; thread2] >>= fun () -> 
+       Lwt.join [thread1; thread2] >>= fun () ->
        Lwt_unix.close fd >>= fun () ->
        Lwt_unix.close localfd)
     (fun _ ->
-       ignore_exn (fun () -> Lwt_unix.close fd) () >>= fun () -> 
+       ignore_exn (fun () -> Lwt_unix.close fd) () >>= fun () ->
        ignore_exn (fun () -> Lwt_unix.close localfd) ())
-  >>= fun () -> 
+  >>= fun () ->
   Printf.printf "FD closed: %b %b\n" Lwt_unix.(state fd == Closed) Lwt_unix.(state localfd == Closed)
   |> Lwt.return
 
@@ -105,15 +105,15 @@ let handler sock msg =
   | [protocol;sport] ->
     let port = int_of_string sport in
     proxy sock protocol "hybi10" port
-  | _ -> 
+  | _ ->
     ignore_exn (fun () -> Lwt_unix.close sock) () >>= fun () ->
     Printf.printf "Sock closed: %b\n" Lwt_unix.(state sock == Closed)
     |> Lwt.return
 
 let _ =
-  if Array.length Sys.argv > 1 
+  if Array.length Sys.argv > 1
   then Lwt.return (Websockets.runtest ())
-  else 
+  else
     begin
       Lwt_daemon.daemonize ~stdout:`Dev_null ~stdin:`Close ~stderr:`Dev_null ();
       let filename = "/var/run/wsproxy.pid" in
@@ -121,7 +121,7 @@ let _ =
       Lwt_main.run begin
         let pid = Unix.getpid () in
         Lwt_io.with_file filename ~mode:Lwt_io.output (fun chan ->
-            Lwt_io.fprintf chan "%d" pid) >>= fun _ -> 
+            Lwt_io.fprintf chan "%d" pid) >>= fun _ ->
         start "wsproxy" handler
       end
     end


### PR DESCRIPTION
Closes leaked file descriptors causing CPU and memory problems after
500 or more connections.

The `ignore_exn` is used to prevent issues if double-closing a
socket/fd, in a similar fashion as what we did in `xapi-nbd` and `nbd`.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>