### PR TITLE
Cleanup code and log structure

### DIFF
--- a/src/lwt_support.ml
+++ b/src/lwt_support.ml
@@ -54,6 +54,7 @@ exception Host_not_found of string
 let open_connection_fd host port =
   let (>>=) = Lwt.bind in
   let s = Lwt_unix.socket Lwt_unix.PF_INET Lwt_unix.SOCK_STREAM 0 in
+  Lwt_unix.setsockopt s Lwt_unix.SO_KEEPALIVE true;
   Lwt_unix.gethostbyname host >>= fun he ->
   if Array.length he.Lwt_unix.h_addr_list = 0
   then (Lwt_unix.close s >>= fun () -> Lwt.fail (Host_not_found host))
@@ -61,4 +62,3 @@ let open_connection_fd host port =
     let addr = Unix.ADDR_INET(ip, port) in
     Lwt_unix.connect s addr >>= fun () ->
     Lwt.return s
-


### PR DESCRIPTION
This also sets the `keepalive` flag to the inet socket. 
This is not enough to fix all the leakings, and does not change much the situation compared to the original fix, but I believe improves the readability of the code.

As @gaborigloi was suggesting we should have a more extensive use of `Lwt.finalize` to make sure we are clearing up everything.

It is worth rewriting the interface to make it more readable and use proper logging in place of `printfs` but, as an intermediate step, I believe this PR is worth merging.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>