### PR TITLE
[opam/next] cli/wsproxy.ml: fix compilation with Lwt 3

### DIFF
--- a/cli/wsproxy.ml
+++ b/cli/wsproxy.ml
@@ -28,7 +28,7 @@ let start path handler =
   Lwt.catch
     (fun () -> Lwt_unix.unlink fd_sock_path)
     (fun _ -> Lwt.return_unit) >>= fun () ->
-  let () = Lwt_unix.bind fd_sock (Unix.ADDR_UNIX fd_sock_path) in
+  Lwt_unix.bind fd_sock (Unix.ADDR_UNIX fd_sock_path) >>= fun () ->
   let () = Lwt_unix.listen fd_sock 5 in
 
   let rec loop () =

--- a/wsproxy.opam
+++ b/wsproxy.opam
@@ -12,7 +12,7 @@ build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs ]]
 depends: [
   "jbuilder" {build}
   "base64"
-  "lwt" { < "3.0.0" }
+  "lwt" { >= "3.0.0" }
   "re"
   "uuidm"
   "ounit" {test}


### PR DESCRIPTION
Bind now returns a promise.

This is part of the `opam/next` patches.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>