### PR TITLE
Update base64 to >=3.1.0

### DIFF
--- a/src/websockets.ml
+++ b/src/websockets.ml
@@ -34,9 +34,10 @@ module Wsprotocol (IO : Iteratees.Monad) = struct
     done;
     Buffer.contents result
 
-  let base64encode s = modify B64.encode s
+  let base64encode s = modify Base64.encode_string s
   let base64decode s =
-    let decode x = B64.decode (sanitize x) in
+    let decode x = Base64.decode_exn (sanitize x)
+    in
     modify decode s
 
   let writer = I.writer

--- a/wsproxy.opam
+++ b/wsproxy.opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml"
   "dune" {build}
-  "base64"
+  "base64" {>= "3.1.0"}
   "lwt" {>= "3.0.0"}
   "lwt_log"
   "re"


### PR DESCRIPTION
I'm unsure on what the behaviour should be when the decoding of a sanitized string fails.
The main loop is catching exception so the failure should be logged when it happens.

Signed-off-by: Pau Ruiz Safont <pau.safont@citrix.com>