### PR TITLE
Pull back changes from #21 (Update Lwt logs and remove daemonization)

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,0 +1,9 @@
+profile=ocamlformat
+indicate-multiline-delimiters=closing-on-separate-line
+if-then-else=fit-or-vertical
+dock-collection-brackets=true
+break-struct=natural
+break-separators=before
+break-infix=fit-or-vertical
+break-infix-before-func=false
+sequence-blank-line=preserve-one

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: c
-service: docker
-install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+services: docker
+os: linux
+dist: xenial
+install:
+  - wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+  - wget https://raw.githubusercontent.com/xapi-project/xs-opam/master/tools/xs-opam-ci.env
+  - source xs-opam-ci.env
 script: bash -ex .travis-docker.sh
 env:
   global:
-    - PACKAGE="wsproxy"
     - PINS="wsproxy:."
-    - BASE_REMOTE="https://github.com/xapi-project/xs-opam.git"
-  matrix:
-    - DISTRO="debian-9-ocaml-4.07"
+  jobs:
+    - PACKAGE="wsproxy"

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,5 @@ clean:
 test:
 	dune runtest --profile=$(PROFILE)
 
-reindent:
-	ocp-indent --syntax cstruct -i **/*.mli
-	ocp-indent --syntax cstruct -i **/*.ml
+format:
+	dune build @fmt --auto-promote

--- a/cli/dune
+++ b/cli/dune
@@ -1,5 +1,15 @@
 (executable
   (name wsproxy)
   (public_name wsproxy)
-  (libraries re.str lwt lwt.unix uuidm wslib)
+  (libraries
+   fmt
+   logs
+   logs.fmt
+   logs.lwt
+   lwt
+   lwt.unix
+   re.str
+   uuidm
+   wslib
+  )
 )

--- a/cli/wsproxy.ml
+++ b/cli/wsproxy.ml
@@ -12,8 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 open Wslib
-
-module LwtWsIteratee = Wslib.Websockets.Wsprotocol(Lwt)
+module LwtWsIteratee = Wslib.Websockets.Wsprotocol (Lwt)
 open Lwt.Infix
 
 let with_fd = Lwt_support.with_fd
@@ -25,92 +24,100 @@ let start handler =
 
   let rec loop () =
     let ensure_close = function
-      | [] -> Lwt.return_unit
+      | [] ->
+          Lwt.return_unit
       | fds ->
-        Logs_lwt.warn (fun m -> m "Closing %d excess fds" (List.length fds)) >>= fun () ->
-        List.iter (fun fd -> try Unix.close fd with _ -> ()) fds;
-        Lwt.return_unit
+          Logs_lwt.warn (fun m -> m "Closing %d excess fds" (List.length fds))
+          >>= fun () ->
+          List.iter (fun fd -> try Unix.close fd with _ -> ()) fds ;
+          Lwt.return_unit
     in
     Lwt.catch
       (fun () ->
-         Lwt_unix.accept fd_sock
-         >>= fun (fd_sock',_) ->
-         (* Background thread per connection *)
-         let _ : unit Lwt.t =
-           let buffer = Bytes.make 16384 '\000' in
-           with_fd fd_sock'
-             ~callback:(fun fd ->
-                 let io_vectors = Lwt_unix.IO_vectors.create () in
-                 Lwt_unix.IO_vectors.append_bytes io_vectors buffer 0 16384;
-                 Lwt_unix.Versioned.recv_msg_2 ~socket:fd ~io_vectors)
-           >>= fun (len, newfds) ->
-           match newfds with
-           | [] -> Logs_lwt.warn (fun m -> m "No fd to start a connection: not proxying")
-           | ufd :: ufds ->
-             ensure_close ufds >>= fun () ->
-             with_fd (Lwt_unix.of_unix_file_descr ufd)
-               ~callback:(fun fd ->
-                   Logs_lwt.debug (fun m -> m "About to start connection") >>= fun () ->
-                   Lwt_unix.setsockopt fd Lwt_unix.SO_KEEPALIVE true;
-                   let msg = Bytes.(to_string @@ sub buffer 0 len) in
-                   handler fd msg)
-         in loop ())
+        Lwt_unix.accept fd_sock >>= fun (fd_sock', _) ->
+        (* Background thread per connection *)
+        let (_ : unit Lwt.t) =
+          let buffer = Bytes.make 16384 '\000' in
+          with_fd fd_sock' ~callback:(fun fd ->
+              let io_vectors = Lwt_unix.IO_vectors.create () in
+              Lwt_unix.IO_vectors.append_bytes io_vectors buffer 0 16384 ;
+              Lwt_unix.Versioned.recv_msg_2 ~socket:fd ~io_vectors)
+          >>= fun (len, newfds) ->
+          match newfds with
+          | [] ->
+              Logs_lwt.warn (fun m ->
+                  m "No fd to start a connection: not proxying")
+          | ufd :: ufds ->
+              ensure_close ufds >>= fun () ->
+              with_fd (Lwt_unix.of_unix_file_descr ufd) ~callback:(fun fd ->
+                  Logs_lwt.debug (fun m -> m "About to start connection")
+                  >>= fun () ->
+                  Lwt_unix.setsockopt fd Lwt_unix.SO_KEEPALIVE true ;
+                  let msg = Bytes.(to_string @@ sub buffer 0 len) in
+                  handler fd msg)
+        in
+        loop ())
       (fun e ->
-         Logs_lwt.err (fun m -> m "Caught exception: %s" (Printexc.to_string e)) >>= fun () ->
-         Lwt.return_unit)
+        Logs_lwt.err (fun m -> m "Caught exception: %s" (Printexc.to_string e))
+        >>= fun () -> Lwt.return_unit)
     >>= fun () -> loop ()
-
   in
-  with_fd fd_sock ~callback:(fun _ -> loop ())
 
+  with_fd fd_sock ~callback:(fun _ -> loop ())
 
 let proxy (fd : Lwt_unix.file_descr) addr protocol =
   let open LwtWsIteratee in
   let open Lwt_support in
-  begin match protocol with
-    | "hixie76" ->
+  ( match protocol with
+  | "hixie76" ->
       Logs_lwt.debug (fun m -> m "Old-style (hixie76) protocol") >>= fun () ->
       Lwt.return (wsframe_old, wsunframe_old)
-    | "hybi10" ->
+  | "hybi10" ->
       Logs_lwt.debug (fun m -> m "New-style (hybi10) protocol") >>= fun () ->
       Lwt.return (wsframe, wsunframe)
-    | _ ->
-      Logs_lwt.warn (fun m -> m "Unknown protocol, fallback to hybi10") >>= fun () ->
-      Lwt.return (wsframe, wsunframe)
-  end >>= fun (frame,unframe) ->
+  | _ ->
+      Logs_lwt.warn (fun m -> m "Unknown protocol, fallback to hybi10")
+      >>= fun () -> Lwt.return (wsframe, wsunframe)
+  )
+  >>= fun (frame, unframe) ->
   with_open_connection_fd addr ~callback:(fun localfd ->
       let session_id = Uuidm.v `V4 |> Uuidm.to_string in
-      Logs_lwt.debug (fun m -> m "Starting proxy session %s" session_id) >>= fun () ->
+      Logs_lwt.debug (fun m -> m "Starting proxy session %s" session_id)
+      >>= fun () ->
       let thread1 =
-        lwt_fd_enumerator localfd (frame (writer (really_write fd) "thread1")) >>= fun _ ->
-        Lwt.return_unit in
+        lwt_fd_enumerator localfd (frame (writer (really_write fd) "thread1"))
+        >>= fun _ -> Lwt.return_unit
+      in
       let thread2 =
-        lwt_fd_enumerator fd (unframe (writer (really_write localfd) "thread2")) >>= fun _ ->
-        Lwt.return_unit in
+        lwt_fd_enumerator fd (unframe (writer (really_write localfd) "thread2"))
+        >>= fun _ -> Lwt.return_unit
+      in
       (* closing the connection in one of the threads above in general leaves the other pending forever,
        * by using choose here, we make sure that as soon as one of the threads completes, both are closed *)
-      Lwt.choose [thread1; thread2]
-      >>= fun () -> Logs_lwt.debug (fun m -> m "Closing proxy session %s" session_id))
-
+      Lwt.choose [thread1; thread2] >>= fun () ->
+      Logs_lwt.debug (fun m -> m "Closing proxy session %s" session_id))
 
 module RX = struct
   let socket = Re.Str.regexp "^/var/run/xen/vnc-[0-9]+$"
-  let port   = Re.Str.regexp "^[0-9]+$"
+
+  let port = Re.Str.regexp "^[0-9]+$"
 end
 
 let handler sock msg =
   Logs_lwt.debug (fun m -> m "Got msg: '%s'" msg) >>= fun () ->
   match Re.Str.(split @@ regexp "[:]") msg with
-  | [protocol;_;path]
-  | [protocol;path] when Re.Str.string_match RX.socket path 0 ->
-    let addr = Unix.ADDR_UNIX path in
-    proxy sock addr protocol
-  | [protocol;_;sport]
-  | [protocol;sport] when Re.Str.string_match RX.port sport 0 ->
-    let localhost = Unix.inet_addr_loopback in
-    let addr = Unix.ADDR_INET(localhost, int_of_string sport) in
-    proxy sock addr protocol
-  | _ -> Logs_lwt.warn (fun m -> m "The message '%s' is malformed: not proxying" msg)
+  | ([protocol; _; path] | [protocol; path])
+    when Re.Str.string_match RX.socket path 0 ->
+      let addr = Unix.ADDR_UNIX path in
+      proxy sock addr protocol
+  | ([protocol; _; sport] | [protocol; sport])
+    when Re.Str.string_match RX.port sport 0 ->
+      let localhost = Unix.inet_addr_loopback in
+      let addr = Unix.ADDR_INET (localhost, int_of_string sport) in
+      proxy sock addr protocol
+  | _ ->
+      Logs_lwt.warn (fun m ->
+          m "The message '%s' is malformed: not proxying" msg)
 
 (* Reporter taken from
  * https://erratique.ch/software/logs/doc/Logs_lwt/index.html#report_ex
@@ -118,27 +125,32 @@ let handler sock msg =
 let lwt_reporter () =
   let buf_fmt ~like =
     let b = Buffer.create 512 in
-    Fmt.with_buffer ~like b,
-    fun () -> let m = Buffer.contents b in Buffer.reset b; m
+    ( Fmt.with_buffer ~like b
+    , fun () ->
+        let m = Buffer.contents b in
+        Buffer.reset b ; m )
   in
   let app, app_flush = buf_fmt ~like:Fmt.stdout in
   let dst, dst_flush = buf_fmt ~like:Fmt.stderr in
   let reporter = Logs_fmt.reporter ~app ~dst () in
   let report src level ~over k msgf =
     let k () =
-      let write () = match level with
-      | Logs.App -> Lwt_io.write Lwt_io.stdout (app_flush ())
-      | _ -> Lwt_io.write Lwt_io.stderr (dst_flush ())
+      let write () =
+        match level with
+        | Logs.App ->
+            Lwt_io.write Lwt_io.stdout (app_flush ())
+        | _ ->
+            Lwt_io.write Lwt_io.stderr (dst_flush ())
       in
-      let unblock () = over (); Lwt.return_unit in
-      Lwt.finalize write unblock |> Lwt.ignore_result;
+      let unblock () = over () ; Lwt.return_unit in
+      Lwt.finalize write unblock |> Lwt.ignore_result ;
       k ()
     in
-    reporter.Logs.report src level ~over:(fun () -> ()) k msgf;
+    reporter.Logs.report src level ~over:(fun () -> ()) k msgf
   in
-  { Logs.report = report }
+  {Logs.report}
 
 let _ =
-  Logs.set_reporter (lwt_reporter ());
-  Logs.set_level ~all:true (Some Logs.Info);
+  Logs.set_reporter (lwt_reporter ()) ;
+  Logs.set_level ~all:true (Some Logs.Info) ;
   Lwt_main.run (start handler)

--- a/cli/wsproxy.ml
+++ b/cli/wsproxy.ml
@@ -13,29 +13,21 @@
  *)
 open Wslib
 
-let get_dir_path () = Printf.sprintf "/var/xapi/" 
-
 module LwtWsIteratee = Wslib.Websockets.Wsprotocol(Lwt)
 open Lwt.Infix
 
 let with_fd = Lwt_support.with_fd
 
-let start path handler =
-  let dir_path = get_dir_path () in
-  let fd_sock_path = Printf.sprintf "%s%s" dir_path path in
-  Lwt_log.info_f "Starting wsproxy on %s" fd_sock_path >>= fun () ->
-  let fd_sock = Lwt_unix.socket Unix.PF_UNIX Unix.SOCK_STREAM 0 in
-  Lwt.catch
-    (fun () -> Lwt_unix.unlink fd_sock_path)
-    (fun _ -> Lwt.return_unit) >>= fun () ->
-  Lwt_unix.bind fd_sock (Unix.ADDR_UNIX fd_sock_path) >>= fun () ->
+let start handler =
+  Logs_lwt.info (fun m -> m "Starting wsproxy") >>= fun () ->
+  let fd_sock = Lwt_unix.stdin in
   let () = Lwt_unix.listen fd_sock 5 in
 
   let rec loop () =
     let ensure_close = function
       | [] -> Lwt.return_unit
       | fds ->
-        Lwt_log.warning_f "Closing %d excess fds" (List.length fds) >>= fun () ->
+        Logs_lwt.warn (fun m -> m "Closing %d excess fds" (List.length fds)) >>= fun () ->
         List.iter (fun fd -> try Unix.close fd with _ -> ()) fds;
         Lwt.return_unit
     in
@@ -45,25 +37,26 @@ let start path handler =
          >>= fun (fd_sock',_) ->
          (* Background thread per connection *)
          let _ : unit Lwt.t =
-           let buffer = String.make 16384 '\000' in
+           let buffer = Bytes.make 16384 '\000' in
            with_fd fd_sock'
              ~callback:(fun fd ->
-                let iov = Lwt_unix.io_vector ~buffer ~offset:0 ~length:16384 in
-                Lwt_unix.recv_msg ~socket:fd ~io_vectors:[iov])
+                 let io_vectors = Lwt_unix.IO_vectors.create () in
+                 Lwt_unix.IO_vectors.append_bytes io_vectors buffer 0 16384;
+                 Lwt_unix.Versioned.recv_msg_2 ~socket:fd ~io_vectors)
            >>= fun (len, newfds) ->
            match newfds with
-           | [] -> Lwt_log.warning "No fd to start a connection: not proxying"
+           | [] -> Logs_lwt.warn (fun m -> m "No fd to start a connection: not proxying")
            | ufd :: ufds ->
              ensure_close ufds >>= fun () ->
              with_fd (Lwt_unix.of_unix_file_descr ufd)
                ~callback:(fun fd ->
-                  Lwt_log.debug_f "About to start connection" >>= fun () ->
-                  Lwt_unix.setsockopt fd Lwt_unix.SO_KEEPALIVE true;
-                  let msg = String.sub buffer 0 len in
-                  handler fd msg)
+                   Logs_lwt.debug (fun m -> m "About to start connection") >>= fun () ->
+                   Lwt_unix.setsockopt fd Lwt_unix.SO_KEEPALIVE true;
+                   let msg = Bytes.(to_string @@ sub buffer 0 len) in
+                   handler fd msg)
          in loop ())
       (fun e ->
-         Lwt_log.error_f "Caught exception: %s" (Printexc.to_string e) >>= fun () ->
+         Logs_lwt.err (fun m -> m "Caught exception: %s" (Printexc.to_string e)) >>= fun () ->
          Lwt.return_unit)
     >>= fun () -> loop ()
 
@@ -76,18 +69,18 @@ let proxy (fd : Lwt_unix.file_descr) addr protocol =
   let open Lwt_support in
   begin match protocol with
     | "hixie76" ->
-      Lwt_log.debug_f "Old-style (hixie76) protocol" >>= fun () ->
+      Logs_lwt.debug (fun m -> m "Old-style (hixie76) protocol") >>= fun () ->
       Lwt.return (wsframe_old, wsunframe_old)
     | "hybi10" ->
-      Lwt_log.debug_f "New-style (hybi10) protocol" >>= fun () ->
+      Logs_lwt.debug (fun m -> m "New-style (hybi10) protocol") >>= fun () ->
       Lwt.return (wsframe, wsunframe)
     | _ ->
-      Lwt_log.warning_f "Unknown protocol, fallback to hybi10" >>= fun () ->
-      Lwt.return (wsframe, wsunframe) 
+      Logs_lwt.warn (fun m -> m "Unknown protocol, fallback to hybi10") >>= fun () ->
+      Lwt.return (wsframe, wsunframe)
   end >>= fun (frame,unframe) ->
   with_open_connection_fd addr ~callback:(fun localfd ->
       let session_id = Uuidm.v `V4 |> Uuidm.to_string in
-      Lwt_log.debug_f "Starting proxy session %s" session_id >>= fun () ->
+      Logs_lwt.debug (fun m -> m "Starting proxy session %s" session_id) >>= fun () ->
       let thread1 =
         lwt_fd_enumerator localfd (frame (writer (really_write fd) "thread1")) >>= fun _ ->
         Lwt.return_unit in
@@ -97,7 +90,7 @@ let proxy (fd : Lwt_unix.file_descr) addr protocol =
       (* closing the connection in one of the threads above in general leaves the other pending forever,
        * by using choose here, we make sure that as soon as one of the threads completes, both are closed *)
       Lwt.choose [thread1; thread2]
-      >>= fun () -> Lwt_log.debug_f "Closing proxy session %s" session_id)
+      >>= fun () -> Logs_lwt.debug (fun m -> m "Closing proxy session %s" session_id))
 
 
 module RX = struct
@@ -106,7 +99,7 @@ module RX = struct
 end
 
 let handler sock msg =
-  Lwt_log.debug_f "Got msg: %s" msg >>= fun () ->
+  Logs_lwt.debug (fun m -> m "Got msg: '%s'" msg) >>= fun () ->
   match Re.Str.(split @@ regexp "[:]") msg with
   | [protocol;_;path]
   | [protocol;path] when Re.Str.string_match RX.socket path 0 ->
@@ -117,18 +110,35 @@ let handler sock msg =
     let localhost = Unix.inet_addr_loopback in
     let addr = Unix.ADDR_INET(localhost, int_of_string sport) in
     proxy sock addr protocol
-  | _ -> Lwt_log.warning "Malformed msg: not proxying"
+  | _ -> Logs_lwt.warn (fun m -> m "The message '%s' is malformed: not proxying" msg)
 
+(* Reporter taken from
+ * https://erratique.ch/software/logs/doc/Logs_lwt/index.html#report_ex
+ * under ISC License *)
+let lwt_reporter () =
+  let buf_fmt ~like =
+    let b = Buffer.create 512 in
+    Fmt.with_buffer ~like b,
+    fun () -> let m = Buffer.contents b in Buffer.reset b; m
+  in
+  let app, app_flush = buf_fmt ~like:Fmt.stdout in
+  let dst, dst_flush = buf_fmt ~like:Fmt.stderr in
+  let reporter = Logs_fmt.reporter ~app ~dst () in
+  let report src level ~over k msgf =
+    let k () =
+      let write () = match level with
+      | Logs.App -> Lwt_io.write Lwt_io.stdout (app_flush ())
+      | _ -> Lwt_io.write Lwt_io.stderr (dst_flush ())
+      in
+      let unblock () = over (); Lwt.return_unit in
+      Lwt.finalize write unblock |> Lwt.ignore_result;
+      k ()
+    in
+    reporter.Logs.report src level ~over:(fun () -> ()) k msgf;
+  in
+  { Logs.report = report }
 
-let _ = 
-  (* Enable logging for all levels *)
-  Lwt_log.add_rule "*" Lwt_log.Debug;
-  Lwt_daemon.daemonize ~stdout:`Dev_null ~stdin:`Close ~stderr:`Dev_null ();
-  let filename = "/var/run/wsproxy.pid" in
-  (try Unix.unlink filename with _ -> ());
-  Lwt_main.run begin
-    let pid = Unix.getpid () in
-    Lwt_io.with_file filename ~mode:Lwt_io.output (fun chan ->
-        Lwt_io.fprintf chan "%d" pid) >>= fun _ ->
-    start "wsproxy" handler
-  end
+let _ =
+  Logs.set_reporter (lwt_reporter ());
+  Logs.set_level ~all:true (Some Logs.Info);
+  Lwt_main.run (start handler)

--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,2 @@
-(lang dune 1.4)
+(lang dune 1.11)
+(using fmt 1.2 (enabled_for ocaml))

--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,4 @@
 (library
   (name wslib)
-  (libraries base64 lwt lwt_log lwt.unix)
+  (libraries base64 lwt lwt.unix)
 )

--- a/src/helpers.ml
+++ b/src/helpers.ml
@@ -16,87 +16,104 @@
 
 let split str n =
   let l = String.length str in
-  if n>l
-  then (str,"")
-  else (String.sub str 0 n, String.sub str n (l-n))
+  if n > l then
+    (str, "")
+  else
+    (String.sub str 0 n, String.sub str n (l - n))
 
 let break pred str =
   let l = String.length str in
   let rec inner = function
-    | 0 -> (str,"")
+    | 0 ->
+        (str, "")
     | n ->
-      if pred str.[l-n]
-      then split str (l-n)
-      else inner (n-1)
-  in inner l
+        if pred str.[l - n] then
+          split str (l - n)
+        else
+          inner (n - 1)
+  in
+  inner l
 
 let str_drop_while pred str =
   let l = String.length str in
   let rec inner = function
-    | 0 -> ""
+    | 0 ->
+        ""
     | n ->
-      if pred str.[l-n]
-      then inner (n-1)
-      else String.sub str (l-n) n
-  in inner l
+        if pred str.[l - n] then
+          inner (n - 1)
+        else
+          String.sub str (l - n) n
+  in
+  inner l
 
-let marshal_int ?(bigendian=true) n x =
+let marshal_int ?(bigendian = true) n x =
   let b = Bytes.create n in
   let f =
-    if bigendian
-    then function x -> n-x-1
-    else function x -> x
+    if bigendian then
+      function x -> n - x - 1
+    else
+      function x -> x
   in
   let rec inner num i =
-    if i=n then b else
+    if i = n then
+      b
+    else
       let chr = Int64.logand 0xffL num in
-      Bytes.set b
-        (f i)
-        (char_of_int (Int64.to_int chr));
-      inner (Int64.shift_right_logical num 8) (i+1)
+      Bytes.set b (f i) (char_of_int (Int64.to_int chr)) ;
+      inner (Int64.shift_right_logical num 8) (i + 1)
   in
   inner x 0 |> Bytes.unsafe_to_string
 
 let marshal_int8 x = marshal_int 1 (Int64.of_int x)
+
 let marshal_int16 x = marshal_int 2 (Int64.of_int x)
+
 let marshal_int32 x = marshal_int 4 (Int64.of_int32 x)
+
 let marshal_int64 x = marshal_int 8 x
 
-let unmarshal_int ?(bigendian=true) n s =
-  if String.length s < n then failwith "Invalid argument";
+let unmarshal_int ?(bigendian = true) n s =
+  if String.length s < n then failwith "Invalid argument" ;
   let f =
-    if bigendian
-    then function x -> x
-    else function x -> n-x-1
+    if bigendian then
+      function x -> x
+    else
+      function x -> n - x - 1
   in
   let rec inner acc i =
-    if i=n
-    then acc
+    if i = n then
+      acc
     else
-      let newacc = Int64.logor
-          (Int64.shift_left acc 8)
+      let newacc =
+        Int64.logor (Int64.shift_left acc 8)
           (Int64.of_int (int_of_char s.[f i]))
       in
-      inner newacc (i+1)
-  in inner 0L 0
+      inner newacc (i + 1)
+  in
+  inner 0L 0
 
 let unmarshal_int8 s = Int64.to_int (unmarshal_int 1 s)
+
 let unmarshal_int16 s = Int64.to_int (unmarshal_int 2 s)
+
 let unmarshal_int32 s = Int64.to_int32 (unmarshal_int 4 s)
+
 let unmarshal_int64 s = unmarshal_int 8 s
 
 let unmask mask str =
   match String.length str with
-  | 0 -> str
+  | 0 ->
+      str
   | len ->
-    let buf = Bytes.create len in
-    for i=0 to len - 1 do
-      let j = i mod 4 in
-      let new_char =
-        let str_i = String.get str i |> int_of_char in
-        let mask_j = String.get mask j |> int_of_char in
-        str_i lxor mask_j |> char_of_int
-      in
-      Bytes.set buf i new_char
-    done;
-    Bytes.unsafe_to_string buf
+      let buf = Bytes.create len in
+      for i = 0 to len - 1 do
+        let j = i mod 4 in
+        let new_char =
+          let str_i = str.[i] |> int_of_char in
+          let mask_j = mask.[j] |> int_of_char in
+          str_i lxor mask_j |> char_of_int
+        in
+        Bytes.set buf i new_char
+      done ;
+      Bytes.unsafe_to_string buf

--- a/src/helpers.mli
+++ b/src/helpers.mli
@@ -13,16 +13,29 @@
  *)
 
 val split : string -> int -> string * string
+
 val break : (char -> bool) -> string -> string * string
+
 val str_drop_while : (char -> bool) -> string -> string
+
 val marshal_int : ?bigendian:bool -> int -> int64 -> string
+
 val marshal_int8 : int -> string
+
 val marshal_int16 : int -> string
+
 val marshal_int32 : int32 -> string
+
 val marshal_int64 : int64 -> string
+
 val unmarshal_int : ?bigendian:bool -> int -> string -> int64
+
 val unmarshal_int8 : string -> int
+
 val unmarshal_int16 : string -> int
+
 val unmarshal_int32 : string -> int32
+
 val unmarshal_int64 : string -> int64
+
 val unmask : string -> string -> string

--- a/src/iteratees.ml
+++ b/src/iteratees.ml
@@ -16,20 +16,21 @@ open Helpers
 
 type err = string
 
-type stream =
-  | Eof of err option
-  | Chunk of string
+type stream = Eof of err option | Chunk of string
 
 let string_of_stream = function
-  | Eof (Some x) -> Printf.sprintf "Eof (Some '%s')" x
-  | Eof None -> "Eof None"
-  | Chunk s -> Printf.sprintf "Chunk '%s'" s
-
+  | Eof (Some x) ->
+      Printf.sprintf "Eof (Some '%s')" x
+  | Eof None ->
+      "Eof None"
+  | Chunk s ->
+      Printf.sprintf "Chunk '%s'" s
 
 module type Monad = sig
   type 'a t
 
   val return : 'a -> 'a t
+
   val bind : 'a t -> ('a -> 'b t) -> 'b t
 end
 
@@ -42,29 +43,37 @@ module Iteratee (IO : Monad) = struct
 
   let rec bind i f =
     match i with
-    | IE_done result -> f result
+    | IE_done result ->
+        f result
     | IE_cont (e, k) ->
-      let docase = function
-        | (IE_done x, stream) ->
-          begin match f x with
-            | IE_cont (None, k) -> k stream
-            | x -> IO.return (x, stream)
-          end
-        | (x, stream) ->
-          IO.return (bind x f, stream)
-      in
-      IE_cont (e, fun s -> IO.bind (k s) docase)
+        let docase = function
+          | IE_done x, stream -> (
+            match f x with
+            | IE_cont (None, k) ->
+                k stream
+            | x ->
+                IO.return (x, stream)
+          )
+          | x, stream ->
+              IO.return (bind x f, stream)
+        in
+        IE_cont (e, fun s -> IO.bind (k s) docase)
 
-  let (>>=) = bind
+  let ( >>= ) = bind
 
-  let ie_contM k x = IO.return (IE_cont (None,k), x)
+  let ie_contM k x = IO.return (IE_cont (None, k), x)
+
   let ie_doneM res x = IO.return (IE_done res, x)
+
   let ie_errM msg k x = IO.return (IE_cont (Some msg, k), x)
 
   let state = function
-    | IE_done _           -> "Done"
-    | IE_cont (None,_)    -> "Ready"
-    | IE_cont (Some e, _) -> Printf.sprintf "Error (%s)" e
+    | IE_done _ ->
+        "Done"
+    | IE_cont (None, _) ->
+        "Ready"
+    | IE_cont (Some e, _) ->
+        Printf.sprintf "Error (%s)" e
 
   (* Simplest iteratees *)
 
@@ -72,10 +81,12 @@ module Iteratee (IO : Monad) = struct
     let step st =
       match st with
       | Chunk s ->
-        if String.length s = 0
-        then IO.return (peek, st)
-        else IO.return (IE_done (Some s.[0]), st)
-      | _ -> IO.return (IE_done None, st)
+          if String.length s = 0 then
+            IO.return (peek, st)
+          else
+            IO.return (IE_done (Some s.[0]), st)
+      | _ ->
+          IO.return (IE_done None, st)
     in
     IE_cont (None, step)
 
@@ -83,10 +94,14 @@ module Iteratee (IO : Monad) = struct
     let rec step st =
       match st with
       | Chunk s ->
-        if String.length s = 0
-        then IO.return (head, st)
-        else IO.return (IE_done (Some s.[0]), Chunk (String.sub s 1 (String.length s - 1)))
-      | _ -> IO.return (IE_cont ((Some "Eof"),step), st)
+          if String.length s = 0 then
+            IO.return (head, st)
+          else
+            IO.return
+              ( IE_done (Some s.[0])
+              , Chunk (String.sub s 1 (String.length s - 1)) )
+      | _ ->
+          IO.return (IE_cont (Some "Eof", step), st)
     in
     IE_cont (None, step)
 
@@ -94,10 +109,10 @@ module Iteratee (IO : Monad) = struct
     let rec step st =
       match st with
       | Chunk s ->
-        IO.bind (really_write s)
-          (fun () -> IO.return (IE_cont (None, step), Chunk ""))
+          IO.bind (really_write s) (fun () ->
+              IO.return (IE_cont (None, step), Chunk ""))
       | Eof _ ->
-        IO.return (IE_done (), st)
+          IO.return (IE_done (), st)
     in
     IE_cont (None, step)
 
@@ -106,224 +121,262 @@ module Iteratee (IO : Monad) = struct
   let break pred =
     let rec step before st =
       match st with
-      | Chunk "" -> ie_contM (step before) st
-      | Chunk s ->
-        begin
-          match break pred s with
-          | (_,"") -> ie_contM (step (before^s)) (Chunk "")
-          | (str,tail) -> ie_doneM (before^str) (Chunk tail)
-        end
-      | _ -> IO.return (IE_done before, st)
-    in IE_cont (None, step "")
+      | Chunk "" ->
+          ie_contM (step before) st
+      | Chunk s -> (
+        match break pred s with
+        | _, "" ->
+            ie_contM (step (before ^ s)) (Chunk "")
+        | str, tail ->
+            ie_doneM (before ^ str) (Chunk tail)
+      )
+      | _ ->
+          IO.return (IE_done before, st)
+    in
+    IE_cont (None, step "")
 
   let heads str =
     let rec step cnt str stream =
-      match (stream,str) with
-      | _, ""
-      | Eof _, _ -> IO.return (IE_done cnt, stream)
+      match (stream, str) with
+      | _, "" | Eof _, _ ->
+          IO.return (IE_done cnt, stream)
       | Chunk s, str ->
-        if String.length s = 0
-        then IO.return (IE_cont (None, step 0 str), stream)
-        else
-        if s.[0]=str.[0]
-        then let (_, tl) = split str 1 in step (cnt+1) tl (Chunk (snd (split s 1)))
-        else IO.return (IE_done cnt, stream)
+          if String.length s = 0 then
+            IO.return (IE_cont (None, step 0 str), stream)
+          else if s.[0] = str.[0] then
+            let _, tl = split str 1 in
+            step (cnt + 1) tl (Chunk (snd (split s 1)))
+          else
+            IO.return (IE_done cnt, stream)
     in
     IE_cont (None, step 0 str)
 
   let drop = function
-    | 0 -> IE_done ()
-    | n -> begin
-        let rec step n st = match st with
+    | 0 ->
+        IE_done ()
+    | n ->
+        let rec step n st =
+          match st with
           | Chunk s ->
-            let len = String.length s in
-            if len < n
-            then ie_contM (step (n-len)) (Chunk "")
-            else ie_doneM () (Chunk (String.sub s n (len-n)))
-          | Eof _ -> ie_doneM () st
-        in IE_cont (None, step n)
-      end
+              let len = String.length s in
+              if len < n then
+                ie_contM (step (n - len)) (Chunk "")
+              else
+                ie_doneM () (Chunk (String.sub s n (len - n)))
+          | Eof _ ->
+              ie_doneM () st
+        in
+        IE_cont (None, step n)
 
   let readn = function
-    | 0 -> IE_done ""
-    | n -> begin
+    | 0 ->
+        IE_done ""
+    | n ->
         let rec step acc n st =
           match st with
           | Chunk s ->
-            let len = String.length s in
-            if len < n
-            then ie_contM (step (acc^s) (n-len)) (Chunk "")
-            else
-              let (s1,s2) = split s n in
-              ie_doneM (acc^s1) (Chunk s2)
-          | Eof _ -> ie_errM "EOF" (step acc n) st
-        in IE_cont (None, step "" n)
-      end
+              let len = String.length s in
+              if len < n then
+                ie_contM (step (acc ^ s) (n - len)) (Chunk "")
+              else
+                let s1, s2 = split s n in
+                ie_doneM (acc ^ s1) (Chunk s2)
+          | Eof _ ->
+              ie_errM "EOF" (step acc n) st
+        in
+        IE_cont (None, step "" n)
 
-  let read_int8 = readn 1 >>= (fun s -> return (unmarshal_int8 s))
-  let read_int16 = readn 2 >>= (fun s -> return (unmarshal_int16 s))
-  let read_int32 = readn 4 >>= (fun s -> return (unmarshal_int32 s))
+  let read_int8 = readn 1 >>= fun s -> return (unmarshal_int8 s)
+
+  let read_int16 = readn 2 >>= fun s -> return (unmarshal_int16 s)
+
+  let read_int32 = readn 4 >>= fun s -> return (unmarshal_int32 s)
 
   let drop_while pred =
-    let rec step st = match st with
+    let rec step st =
+      match st with
       | Chunk s ->
-        let news = str_drop_while pred s in
-        if news=""
-        then ie_contM step (Chunk "")
-        else ie_doneM () (Chunk news)
+          let news = str_drop_while pred s in
+          if news = "" then
+            ie_contM step (Chunk "")
+          else
+            ie_doneM () (Chunk news)
       | Eof _ ->
-        ie_doneM () st
+          ie_doneM () st
     in
     IE_cont (None, step)
 
   let accumulate =
-    let rec step acc st = match st with
+    let rec step acc st =
+      match st with
       | Chunk s ->
-        ie_contM (step (acc^s)) (Chunk "")
-      | Eof _ -> ie_doneM acc st
-    in IE_cont (None, step "")
+          ie_contM (step (acc ^ s)) (Chunk "")
+      | Eof _ ->
+          ie_doneM acc st
+    in
+    IE_cont (None, step "")
 
   let apply f =
-    let rec step st = match st with
+    let rec step st =
+      match st with
       | Chunk s ->
-        f s;
-        ie_contM step (Chunk "")
-      | Eof _ -> ie_doneM () st
-    in IE_cont (None, step)
+          f s ; ie_contM step (Chunk "")
+      | Eof _ ->
+          ie_doneM () st
+    in
+    IE_cont (None, step)
 
   let liftI m =
     let step st i =
       match i with
-      | IE_cont (None, k) -> k st
-      | IE_cont (Some _, _) | IE_done _ -> IO.return (i,st)
+      | IE_cont (None, k) ->
+          k st
+      | IE_cont (Some _, _) | IE_done _ ->
+          IO.return (i, st)
     in
     IE_cont (None, fun s -> IO.bind m (step s))
 
-
-
   (* ****************************** ENUMERATORS *********************************)
 
-  type 'a enumerator = 'a t -> ('a t) IO.t
+  type 'a enumerator = 'a t -> 'a t IO.t
 
   (* Simplest enumarator *)
 
   let enum_eof i =
     let result =
       match i with
-      | IE_cont (None, f) -> IO.bind (f (Eof None)) (fun x -> IO.return (fst x))
-      | _ -> IO.return i
+      | IE_cont (None, f) ->
+          IO.bind (f (Eof None)) (fun x -> IO.return (fst x))
+      | _ ->
+          IO.return i
     in
     IO.bind result (function
-        | IE_done _ -> result
-        | IE_cont (Some _, _) -> result
-        | _ -> failwith "Divergent Iteratee")
+      | IE_done _ ->
+          result
+      | IE_cont (Some _, _) ->
+          result
+      | _ ->
+          failwith "Divergent Iteratee")
 
   let enum_1chunk str = function
-    | IE_cont (None, f) -> IO.bind (f (Chunk str)) (fun x -> IO.return (fst x))
-    | x -> IO.return x
+    | IE_cont (None, f) ->
+        IO.bind (f (Chunk str)) (fun x -> IO.return (fst x))
+    | x ->
+        IO.return x
 
   let rec enum_nchunk str n =
-    if str="" then (fun x -> IO.return x) else
-      let (str1,str2) = split str n in
+    if str = "" then
+      fun x -> IO.return x
+    else
+      let str1, str2 = split str n in
       function
       | IE_cont (None, f) ->
-        IO.bind (IO.bind (f (Chunk str1))
-                   (fun x -> IO.return (fst x))) (enum_nchunk str2 n)
-      | x -> IO.return x
+          IO.bind
+            (IO.bind (f (Chunk str1)) (fun x -> IO.return (fst x)))
+            (enum_nchunk str2 n)
+      | x ->
+          IO.return x
 
   let extract_result_from_iteratee = function
-    | IE_done x -> x
-    | _ -> failwith "Not done!"
+    | IE_done x ->
+        x
+    | _ ->
+        failwith "Not done!"
 
-  type 'a enumeratee = 'a t -> ('a t) t
+  type 'a enumeratee = 'a t -> 'a t t
 
   let rec take =
     let step n k s =
       match s with
       | Chunk str ->
-        let len = String.length str in
-        if len < n
-        then
-          IO.bind (k s) (fun (i, _) ->
-              IO.return (take (n-len) i, Chunk ""))
-        else
-          let (str1,str2) = split str n in
-          IO.bind (k (Chunk str1)) (fun (i,_) ->
-              IO.return (IE_done i, Chunk str2))
+          let len = String.length str in
+          if len < n then
+            IO.bind (k s) (fun (i, _) -> IO.return (take (n - len) i, Chunk ""))
+          else
+            let str1, str2 = split str n in
+            IO.bind (k (Chunk str1)) (fun (i, _) ->
+                IO.return (IE_done i, Chunk str2))
       | Eof _ ->
-        IO.bind (k s) (fun (i, _) -> IO.return (IE_done i, s))
+          IO.bind (k s) (fun (i, _) -> IO.return (IE_done i, s))
     in
     function
-    | 0 -> return
-    | n ->
-      fun s -> match s with
-        | IE_cont (None,k) -> IE_cont (None, (step n k))
-        | IE_cont (Some _, _)
-        | IE_done _ -> bind (drop n) (fun () -> return s)
+    | 0 ->
+        return
+    | n -> (
+        fun s ->
+          match s with
+          | IE_cont (None, k) ->
+              IE_cont (None, step n k)
+          | IE_cont (Some _, _) | IE_done _ ->
+              bind (drop n) (fun () -> return s)
+      )
 
   let stream_printer name =
     let rec step k s =
-      Printf.printf "%s: %s\n" name (string_of_stream s);
+      Printf.printf "%s: %s\n" name (string_of_stream s) ;
       IO.bind (k s) (fun i ->
           match i with
-          | (IE_cont (None, f), s) -> IO.return (IE_cont (None, step f), s)
-          | (IE_cont (err, f), s) -> IO.return (IE_cont (err, step f), s)
-          | (i, s) -> IO.return (IE_done i, s))
-    in fun s -> match s with
-      | IE_cont (None,k) -> IE_cont (None, (step k))
-      | IE_cont (Some _, _)
-      | IE_done _ -> return s
+          | IE_cont (None, f), s ->
+              IO.return (IE_cont (None, step f), s)
+          | IE_cont (err, f), s ->
+              IO.return (IE_cont (err, step f), s)
+          | i, s ->
+              IO.return (IE_done i, s))
+    in
+    fun s ->
+      match s with
+      | IE_cont (None, k) ->
+          IE_cont (None, step k)
+      | IE_cont (Some _, _) | IE_done _ ->
+          return s
 
   let modify f =
     let rec step k s =
       match s with
       | Chunk c ->
-        let s = try f c with e -> Printf.printf "got exception %s\n%!" (Printexc.to_string e); raise e in
-        IO.bind (k (Chunk s)) (fun i ->
-            match i with
-            | (IE_cont (None, f), s) -> IO.return (IE_cont (None, step f), s)
-            | (IE_cont (err, f), s) -> IO.return (IE_cont (err, step f), s)
-            | (i, s) -> IO.return (IE_done i, s))
+          let s =
+            try f c
+            with e ->
+              Printf.printf "got exception %s\n%!" (Printexc.to_string e) ;
+              raise e
+          in
+          IO.bind (k (Chunk s)) (fun i ->
+              match i with
+              | IE_cont (None, f), s ->
+                  IO.return (IE_cont (None, step f), s)
+              | IE_cont (err, f), s ->
+                  IO.return (IE_cont (err, step f), s)
+              | i, s ->
+                  IO.return (IE_done i, s))
       | Eof _ ->
-        IO.bind (k s) (fun (i,_) -> IO.return (IE_done i, s))
-    in fun s -> match s with
+          IO.bind (k s) (fun (i, _) -> IO.return (IE_done i, s))
+    in
+    fun s ->
+      match s with
       | IE_cont (None, k) ->
-        IE_cont (None, step k)
+          IE_cont (None, step k)
       | IE_cont (Some _, _) ->
-        return s
-      | IE_done _ -> return s
+          return s
+      | IE_done _ ->
+          return s
 
   type 'a either = Left of 'a | Right of 'a
 
   let read_lines =
-    let (>>=) = bind in
-    let iscrlf = function | '\r' | '\n' -> true | _ -> false in
-    let terminators = heads "\r\n" >>= function | 0 -> heads "\n" | n -> return n in
+    let ( >>= ) = bind in
+    let iscrlf = function '\r' | '\n' -> true | _ -> false in
+    let terminators =
+      heads "\r\n" >>= function 0 -> heads "\n" | n -> return n
+    in
     let rec lines' acc = break iscrlf >>= fun l -> terminators >>= check acc l
     and check acc l n =
-      match (l,n) with
-      | (_,0)  -> return (Left (List.rev acc))
-      | ("",_) -> return (Right (List.rev acc))
-      | (l,_)  -> lines' (l::acc)
+      match (l, n) with
+      | _, 0 ->
+          return (Left (List.rev acc))
+      | "", _ ->
+          return (Right (List.rev acc))
+      | l, _ ->
+          lines' (l :: acc)
     in
     lines' []
-
 end
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/iteratees.mli
+++ b/src/iteratees.mli
@@ -22,133 +22,136 @@ type err = string
 
 (** The stream type is the stuff provided by enumerators to give to iteratees *)
 type stream = Eof of err option | Chunk of string
+
 val string_of_stream : stream -> string
 
-
 (** The most basic Monad module definition. *)
-module type Monad =
-sig
+module type Monad = sig
   type 'a t
+
   val return : 'a -> 'a t
+
   val bind : 'a t -> ('a -> 'b t) -> 'b t
 end
 
 (** Iteratee module, functorized over a monad module *)
-module Iteratee :
-  functor (IO : Monad) ->
-  sig
-    (** The type t describes the current state of the iteratee.
+module Iteratee : functor (IO : Monad) -> sig
+  (** The type t describes the current state of the iteratee.
         It's either 'Done', in which case it's got some sort of
         value, or it's in the 'Cont' state, which mean's it
         hasn't finished processing - in this case it may be in
         an error state, or it may be awaiting more input.
     *)
 
-    type 'a t =
-        IE_done of 'a
-      | IE_cont of err option * (stream -> ('a t * stream) IO.t)
+  type 'a t =
+    | IE_done of 'a
+    | IE_cont of err option * (stream -> ('a t * stream) IO.t)
 
-    (** Iteratee is itself a monad, with the usual return, bind *)
-    val return : 'a -> 'a t
-    val bind : 'a t -> ('a -> 'b t) -> 'b t
-    val ( >>= ) : 'a t -> ('a -> 'b t) -> 'b t
+  val return : 'a -> 'a t
+  (** Iteratee is itself a monad, with the usual return, bind *)
 
-    val ie_contM :
-      (stream -> ('a t * stream) IO.t) -> 'b -> ('a t * 'b) IO.t
-    val ie_doneM : 'a -> 'b -> ('a t * 'b) IO.t
-    val ie_errM :
-      err -> (stream -> ('a t * stream) IO.t) -> 'b -> ('a t * 'b) IO.t
+  val bind : 'a t -> ('a -> 'b t) -> 'b t
 
-    (** Return a string representation of the state of the monad *)
-    val state : 'a t -> string
+  val ( >>= ) : 'a t -> ('a -> 'b t) -> 'b t
 
-    (** Here are the first iteratees
+  val ie_contM : (stream -> ('a t * stream) IO.t) -> 'b -> ('a t * 'b) IO.t
+
+  val ie_doneM : 'a -> 'b -> ('a t * 'b) IO.t
+
+  val ie_errM :
+    err -> (stream -> ('a t * stream) IO.t) -> 'b -> ('a t * 'b) IO.t
+
+  val state : 'a t -> string
+  (** Return a string representation of the state of the monad *)
+
+  val peek : char option t
+  (** Here are the first iteratees
         peek - iteratee that look at the first character in the stream
         without consuming it
     *)
-    val peek : char option t
 
-    (** head - iteratee that remove and return the first character in the stream *)
-    val head : char option t
+  val head : char option t
+  (** head - iteratee that remove and return the first character in the stream *)
 
-    (** writer - a generic writer iteratee. Takes an argument of type
+  val writer : (string -> unit IO.t) -> string -> unit t
+  (** writer - a generic writer iteratee. Takes an argument of type
         'string -> unit IO.t' *)
-    val writer : (string -> unit IO.t) -> string -> unit t
 
-    (** break - iteratee that stops consuming input when the supplied predicate is met,
+  val break : (char -> bool) -> string t
+  (** break - iteratee that stops consuming input when the supplied predicate is met,
         then returns the string so far *)
-    val break : (char -> bool) -> string t
 
-    (** heads - iteratee that matches character for character the incoming stream and
+  val heads : string -> int t
+  (** heads - iteratee that matches character for character the incoming stream and
         the string passed in, then returns the number of characters that
         matched *)
-    val heads : string -> int t
 
-    (** drop - iteratee that consumes and ignores n characters of the stream *)
-    val drop : int -> unit t
+  val drop : int -> unit t
+  (** drop - iteratee that consumes and ignores n characters of the stream *)
 
-    (** readn - iteratee that reads exactly n characters from the stream *)
-    val readn : int -> string t
+  val readn : int -> string t
+  (** readn - iteratee that reads exactly n characters from the stream *)
 
-    (** read_int8 - reads an int8 from the stream *)
-    val read_int8 : int t
+  val read_int8 : int t
+  (** read_int8 - reads an int8 from the stream *)
 
-    (** read_int16 - reads an int16 from the stream (bigendian byte order) *)
-    val read_int16 : int t
+  val read_int16 : int t
+  (** read_int16 - reads an int16 from the stream (bigendian byte order) *)
 
-    (** read_int32 - reads an int32 from the stream (bigendian byte order) *)
-    val read_int32 : int32 t
+  val read_int32 : int32 t
+  (** read_int32 - reads an int32 from the stream (bigendian byte order) *)
 
-    (** drop_while - iteratee that drops characters from the stream while they
+  val drop_while : (char -> bool) -> unit t
+  (** drop_while - iteratee that drops characters from the stream while they
         satisfy the supplied predicate *)
-    val drop_while : (char -> bool) -> unit t
 
-    (** accumulate - Simply accumulate the stream until EOF *)
-    val accumulate : string t
+  val accumulate : string t
+  (** accumulate - Simply accumulate the stream until EOF *)
 
-    (** apply - applies the chunks to the supplied function (for side effect) *)
-    val apply : (string -> unit) -> unit t
+  val apply : (string -> unit) -> unit t
+  (** apply - applies the chunks to the supplied function (for side effect) *)
 
-    (** liftI - turn an iteratee hiding inside the monad into an iteratee *)
-    val liftI : 'a t IO.t -> 'a t
+  val liftI : 'a t IO.t -> 'a t
+  (** liftI - turn an iteratee hiding inside the monad into an iteratee *)
 
-    (** Enumerators *)
+  (** Enumerators *)
 
-    (** An enumerator takes an 'a iteratee and gives you back an 'a iteratee *)
-    type 'a enumerator = 'a t -> 'a t IO.t
+  (** An enumerator takes an 'a iteratee and gives you back an 'a iteratee *)
+  type 'a enumerator = 'a t -> 'a t IO.t
 
-    (** enum_eof - Supply the EOF stream to the iteratee *)
-    val enum_eof : 'a t -> 'a t IO.t
+  val enum_eof : 'a t -> 'a t IO.t
+  (** enum_eof - Supply the EOF stream to the iteratee *)
 
-    (** enum_1chunk - Give the supplied string to the iteratee in one chunk *)
-    val enum_1chunk : string -> 'a t -> 'a t IO.t
+  val enum_1chunk : string -> 'a t -> 'a t IO.t
+  (** enum_1chunk - Give the supplied string to the iteratee in one chunk *)
 
-    (** enum_nchunk - Gives the supplied string to the iteratee in chunks of length n.
+  val enum_nchunk : string -> int -> 'a t -> 'a t IO.t
+  (** enum_nchunk - Gives the supplied string to the iteratee in chunks of length n.
         Good for testing *)
-    val enum_nchunk : string -> int -> 'a t -> 'a t IO.t
 
-    (** extract_result_from_iteratee - Given a 'done' iteratee, pull the result out *)
-    val extract_result_from_iteratee : 'a t -> 'a
+  val extract_result_from_iteratee : 'a t -> 'a
+  (** extract_result_from_iteratee - Given a 'done' iteratee, pull the result out *)
 
-    (** Enumeratees *)
+  (** Enumeratees *)
 
-    (** An enumeratee is a function that takes an iteratee and returns a new iteratee.
+  (** An enumeratee is a function that takes an iteratee and returns a new iteratee.
         It acts as an iteratee to the outside world, but as an enumerator to the supplied
         iteratee *)
-    type 'a enumeratee = 'a t -> 'a t t
+  type 'a enumeratee = 'a t -> 'a t t
 
-    (** take - takes exactly n characters from the input stream and applies them to
+  val take : int -> 'a t -> 'a t t
+  (** take - takes exactly n characters from the input stream and applies them to
         the inner stream *)
-    val take : int -> 'a t -> 'a t t
 
-    (** stream_printer - given a name and an iteratee i, returns an iteratee that
+  val stream_printer : string -> 'a t -> 'a t t
+  (** stream_printer - given a name and an iteratee i, returns an iteratee that
         will print the chunks supplied before handing them off to the iteratee *)
-    val stream_printer : string -> 'a t -> 'a t t
 
-    (** modify - Modify the stream in some way before giving the result to the
+  val modify : (string -> string) -> 'a t -> 'a t t
+  (** modify - Modify the stream in some way before giving the result to the
         inner stream. For example, one could base64 encode things this way *)
-    val modify : (string -> string) -> 'a t -> 'a t t
 
-    type 'a either = Left of 'a | Right of 'a
-    val read_lines : string list either t
-  end
+  type 'a either = Left of 'a | Right of 'a
+
+  val read_lines : string list either t
+end

--- a/src/lwt_support.mli
+++ b/src/lwt_support.mli
@@ -14,33 +14,32 @@
 
 type 'a t = 'a Iteratees.Iteratee(Lwt).t =
   | IE_done of 'a
-  | IE_cont of Iteratees.err option * (Iteratees.stream -> ('a t * Iteratees.stream) Lwt.t)
+  | IE_cont of
+      Iteratees.err option
+      * (Iteratees.stream -> ('a t * Iteratees.stream) Lwt.t)
 
+val really_write : Lwt_unix.file_descr -> string -> unit Lwt.t
 (** Really write a string to a file descriptor - repeats until the whole
     string is done *)
-val really_write : Lwt_unix.file_descr -> string -> unit Lwt.t
 
-(** Read from an Lwt fd and send the chunks to an iteratee *)
 val lwt_fd_enumerator : Lwt_unix.file_descr -> 'a t -> 'a t Lwt.t
+(** Read from an Lwt fd and send the chunks to an iteratee *)
 
-(** Read from a named file and send the chunks to an iteratee *)
 val lwt_enumerator : string -> 'a t -> 'a t Lwt.t
+(** Read from a named file and send the chunks to an iteratee *)
 
 exception Host_not_found of string
 
+val with_fd :
+  Lwt_unix.file_descr -> callback:(Lwt_unix.file_descr -> 'a Lwt.t) -> 'a Lwt.t
 (** Given a file descriptor (Lwt), it executes the function 
     [callback] passing it the connected file descriptor, ensuring to close
     the file descriptor when returning. *)
-val with_fd: Lwt_unix.file_descr
-  -> callback:(Lwt_unix.file_descr -> 'a Lwt.t)
-  -> 'a Lwt.t
 
 (** Given socket, open a connection and execute the function
     [callback] passing it the connected file descriptor, ensuring to
     close the file descriptor when returning.  The function can fail
     with Unix exceptions and Host_not_found. *)
 
-val with_open_connection_fd : Unix.sockaddr
-  -> callback:(Lwt_unix.file_descr -> 'a Lwt.t)
-  -> 'a Lwt.t
-
+val with_open_connection_fd :
+  Unix.sockaddr -> callback:(Lwt_unix.file_descr -> 'a Lwt.t) -> 'a Lwt.t

--- a/src/websockets.ml
+++ b/src/websockets.ml
@@ -15,8 +15,7 @@
 (* Websockets protocol here *)
 
 module Wsprotocol (IO : Iteratees.Monad) = struct
-
-  module I = Iteratees.Iteratee(IO)
+  module I = Iteratees.Iteratee (IO)
   open I
 
   type 'a t = 'a I.t
@@ -27,89 +26,89 @@ module Wsprotocol (IO : Iteratees.Monad) = struct
      * Note: \t = \009, \n = \012, \r = \015, \s = \032 *)
     let result = Buffer.create (String.length s) in
     for i = 0 to String.length s - 1 do
-      if (String.unsafe_get s i >= '\000' && String.unsafe_get s i <= '\032')
-      || String.unsafe_get s i = '\127'
-      then ()
-      else Buffer.add_char result (String.unsafe_get s i)
-    done;
+      if
+        (String.unsafe_get s i >= '\000' && String.unsafe_get s i <= '\032')
+        || String.unsafe_get s i = '\127'
+      then
+        ()
+      else
+        Buffer.add_char result (String.unsafe_get s i)
+    done ;
     Buffer.contents result
 
   let base64encode s = modify Base64.encode_string s
+
   let base64decode s =
-    let decode x = Base64.decode_exn (sanitize x)
-    in
+    let decode x = Base64.decode_exn (sanitize x) in
     modify decode s
 
   let writer = I.writer
 
-  let wsframe s = modify (fun s ->
-      let l = String.length s in
-      if l < 126
-      then
-        Printf.sprintf "%c%c%s" (char_of_int 0x82) (char_of_int l) s
-      else if l < 65535
-      then
-        Printf.sprintf "%c%c%s%s" (char_of_int 0x82) (char_of_int 126)
-          (Helpers.marshal_int16 l) s
-      else
-        Printf.sprintf "%c%c%s%s" (char_of_int 0x82) (char_of_int 127)
-          (Helpers.marshal_int32 (Int32.of_int l)) s) s
+  let wsframe s =
+    modify
+      (fun s ->
+        let l = String.length s in
+        if l < 126 then
+          Printf.sprintf "%c%c%s" (char_of_int 0x82) (char_of_int l) s
+        else if l < 65535 then
+          Printf.sprintf "%c%c%s%s" (char_of_int 0x82) (char_of_int 126)
+            (Helpers.marshal_int16 l) s
+        else
+          Printf.sprintf "%c%c%s%s" (char_of_int 0x82) (char_of_int 127)
+            (Helpers.marshal_int32 (Int32.of_int l))
+            s)
+      s
 
   let wsframe_old s = modify (fun s -> Printf.sprintf "\x00%s\xff" s) s
 
   let rec wsunframe x =
-    let read_sz =
-      read_int8 >>= fun sz ->
-      return (sz >= 128, sz land 0x7f)
-    in
+    let read_sz = read_int8 >>= fun sz -> return (sz >= 128, sz land 0x7f) in
     let read_size sz =
-      if sz < 126
-      then return sz
+      if sz < 126 then
+        return sz
       else if sz = 126 then
         read_int16
       else (* sz = 127 *)
         read_int32 >>= fun x -> return (Int32.to_int x)
     in
     let read_mask has_mask =
-      if has_mask
-      then readn 4
-      else return "\x00\x00\x00\x00"
+      if has_mask then
+        readn 4
+      else
+        return "\x00\x00\x00\x00"
     in
     let rec inner acc s =
       match s with
       | IE_cont (None, k) ->
-        begin
-          read_int8                    >>= fun op ->
-          read_sz                      >>= fun (has_mask, sz) ->
-          read_size sz                 >>= fun size ->
-          read_mask has_mask           >>= fun mask ->
-          readn size                   >>= fun str ->
+          read_int8 >>= fun op ->
+          read_sz >>= fun (has_mask, sz) ->
+          read_size sz >>= fun size ->
+          read_mask has_mask >>= fun mask ->
+          readn size >>= fun str ->
           let real_str = Helpers.unmask mask str in
-          if op land 0x0f = 0x08
-          then (* close frame *)
+          if op land 0x0f = 0x08 then (* close frame *)
             return s
-          else
-          if not (op land 0x80 = 0x80)
-          then begin
+          else if not (op land 0x80 = 0x80) then
             inner (acc ^ real_str) s
-          end else begin
-            liftI (IO.bind (k (Iteratees.Chunk (acc ^ real_str))) (fun (i, _) ->
-                IO.return (wsunframe i)))
-          end
-        end
-      | _ -> return s
-    in inner "" x
+          else
+            liftI
+              (IO.bind
+                 (k (Iteratees.Chunk (acc ^ real_str)))
+                 (fun (i, _) -> IO.return (wsunframe i)))
+      | _ ->
+          return s
+    in
+    inner "" x
 
   let rec wsunframe_old s =
     match s with
     | IE_cont (None, k) ->
-      begin
         heads "\x00" >>= fun _ ->
-        break ((=) '\xff') >>= fun str ->
+        break (( = ) '\xff') >>= fun str ->
         drop 1 >>= fun () ->
-        liftI (IO.bind (k (Iteratees.Chunk str)) (fun (i,_) ->
-            IO.return (wsunframe_old i)))
-      end
-    | _ -> return s
-
+        liftI
+          (IO.bind (k (Iteratees.Chunk str)) (fun (i, _) ->
+               IO.return (wsunframe_old i)))
+    | _ ->
+        return s
 end

--- a/src/websockets.mli
+++ b/src/websockets.mli
@@ -12,35 +12,33 @@
  * GNU Lesser General Public License for more details.
  *)
 
-module Wsprotocol :
-  functor (IO : Iteratees.Monad) ->
-  sig
-    type 'a t = 'a Iteratees.Iteratee(IO).t
+module Wsprotocol : functor (IO : Iteratees.Monad) -> sig
+  type 'a t = 'a Iteratees.Iteratee(IO).t
 
-    (** Exposing the writer from the IO Iteratee *)
-    val writer : (string -> unit IO.t) -> string -> unit t
+  val writer : (string -> unit IO.t) -> string -> unit t
+  (** Exposing the writer from the IO Iteratee *)
 
-    (** enumeratee that base64 encodes individual chunks
+  val base64encode : 'a t -> 'a t t
+  (** enumeratee that base64 encodes individual chunks
         and passes them onto the sub-iteratee *)
-    val base64encode : 'a t -> 'a t t
 
-    (** enumeratee that base64 decodes individual chunks
+  val base64decode : 'a t -> 'a t t
+  (** enumeratee that base64 decodes individual chunks
         and passes them onto the sub-iteratee *)
-    val base64decode : 'a t -> 'a t t
 
-    (** enumeratee that websocket-encodes data and
+  val wsframe : 'a t -> 'a t t
+  (** enumeratee that websocket-encodes data and
         passes the encoded data to the sub-iteratee *)
-    val wsframe : 'a t -> 'a t t
 
-    (** enumeratee that old-style websocket-encodes data and
+  val wsframe_old : 'a t -> 'a t t
+  (** enumeratee that old-style websocket-encodes data and
         passes the encoded data to the sub-iteratee *)
-    val wsframe_old : 'a t -> 'a t t
 
-    (** enumeratee that websocket-decodes data and
+  val wsunframe : 'a t -> 'a t t
+  (** enumeratee that websocket-decodes data and
         passes the decoded data to the sub-iteratee *)
-    val wsunframe : 'a t -> 'a t t
 
-    (** enumeratee that old-style websocket-decodes data and
+  val wsunframe_old : 'a t -> 'a t t
+  (** enumeratee that old-style websocket-decodes data and
         passes the decoded data to the sub-iteratee *)
-    val wsunframe_old : 'a t -> 'a t t
-  end
+end

--- a/test/test.ml
+++ b/test/test.ml
@@ -12,28 +12,26 @@
  * GNU Lesser General Public License for more details.
  *)
 
-
 module NoOpMonad = struct
   type 'a t = 'a
 
   let return a = a
+
   let bind x f = f x
 end
 
 module StringMonad = struct
-  type 'a t =
-    { data : 'a;
-      str : string }
-  let return a = { data=a; str=""; }
+  type 'a t = {data: 'a; str: string}
+
+  let return a = {data= a; str= ""}
+
   let bind x f =
     let newstr = f x.data in
-    {newstr with str = x.str ^ newstr.str}
+    {newstr with str= x.str ^ newstr.str}
 
-  let strwr x =
-    { data=(); str=x }
+  let strwr x = {data= (); str= x}
+
   let getstr x = x.str
+
   let getdata x = x.data
 end
-
-
-

--- a/test/test.mli
+++ b/test/test.mli
@@ -12,20 +12,24 @@
  * GNU Lesser General Public License for more details.
  *)
 
-
-module NoOpMonad :
-sig
+module NoOpMonad : sig
   type 'a t = 'a
+
   val return : 'a -> 'a
+
   val bind : 'a -> ('a -> 'b) -> 'b
 end
 
-module StringMonad :
-sig
-  type 'a t = { data : 'a; str : string; }
+module StringMonad : sig
+  type 'a t = {data: 'a; str: string}
+
   val return : 'a -> 'a t
+
   val bind : 'a t -> ('a -> 'b t) -> 'b t
+
   val strwr : string -> unit t
+
   val getstr : 'a t -> string
+
   val getdata : 'a t -> 'a
 end

--- a/test/test_helpers.ml
+++ b/test/test_helpers.ml
@@ -15,79 +15,80 @@
 open OUnit
 open Wslib
 
-let gen_nums n generator =
-  QCheck.Gen.generate n generator
+let gen_nums n generator = QCheck.Gen.generate n generator
 
 let test_split () =
-  let (a, b) = Helpers.split "helper" 2 in
-  assert_equal a "he";
-  assert_equal b "lper"
+  let a, b = Helpers.split "helper" 2 in
+  assert_equal a "he" ; assert_equal b "lper"
 
 let test_break () =
-  let pred = function | 'x' -> true | _ -> false in
-  let (a, b) = Helpers.break pred "helper" in
-  assert_equal a "helper";
-  assert_equal b "";
-  let (a, b) = Helpers.break pred "helxper" in
-  assert_equal a "hel";
-  assert_equal b "xper"
+  let pred = function 'x' -> true | _ -> false in
+  let a, b = Helpers.break pred "helper" in
+  assert_equal a "helper" ;
+  assert_equal b "" ;
+  let a, b = Helpers.break pred "helxper" in
+  assert_equal a "hel" ; assert_equal b "xper"
 
 let test_str_drop_while () =
-  let pred = function | 'x' -> true | _ -> false in
+  let pred = function 'x' -> true | _ -> false in
   let a = Helpers.str_drop_while pred "helper" in
-  assert_equal a "helper";
+  assert_equal a "helper" ;
   let b = Helpers.str_drop_while pred "xhelper" in
   assert_equal b "helper"
 
 let test_marshal_unmarshal_int () =
   let generator = QCheck.Gen.ui64 in
   let nums = gen_nums 10 generator in
-  List.iter (fun i ->
-    assert_equal i (Helpers.unmarshal_int 8 (Helpers.marshal_int 8 i))
-  ) nums
+  List.iter
+    (fun i ->
+      assert_equal i (Helpers.unmarshal_int 8 (Helpers.marshal_int 8 i)))
+    nums
 
 let test_marshal_unmarshal_int8 () =
   let generator = QCheck.Gen.int_bound 255 in
   let nums = gen_nums 10 generator in
-  List.iter (fun i ->
-    assert_equal i (Helpers.unmarshal_int8 (Helpers.marshal_int8 i))
-  ) nums
+  List.iter
+    (fun i -> assert_equal i (Helpers.unmarshal_int8 (Helpers.marshal_int8 i)))
+    nums
 
 let test_marshal_unmarshal_int16 () =
   let generator = QCheck.Gen.int_bound 65535 in
   let nums = gen_nums 10 generator in
-  List.iter (fun i ->
-    assert_equal i (Helpers.unmarshal_int16 (Helpers.marshal_int16 i))
-  ) nums
+  List.iter
+    (fun i ->
+      assert_equal i (Helpers.unmarshal_int16 (Helpers.marshal_int16 i)))
+    nums
 
 let test_marshal_unmarshal_int32 () =
   let generator = QCheck.Gen.ui32 in
   let nums = gen_nums 10 generator in
-  List.iter (fun i ->
-    assert_equal i (Helpers.unmarshal_int32 (Helpers.marshal_int32 i))
-  ) nums
+  List.iter
+    (fun i ->
+      assert_equal i (Helpers.unmarshal_int32 (Helpers.marshal_int32 i)))
+    nums
 
 let test_marshal_unmarshal_int64 () =
   let generator = QCheck.Gen.ui64 in
   let nums = gen_nums 10 generator in
-  List.iter (fun i ->
-    assert_equal i (Helpers.unmarshal_int64 (Helpers.marshal_int64 i))
-  ) nums
+  List.iter
+    (fun i ->
+      assert_equal i (Helpers.unmarshal_int64 (Helpers.marshal_int64 i)))
+    nums
 
 let test_unmask () =
   let a = Helpers.unmask "01010101" "\x01\x01\x01\x01\x01\x01\x01\x01" in
   assert_equal a "10101010"
 
 let test =
-  "test_helpers" >:::
-  [
-    "test_split" >:: test_split;
-    "test_break" >:: test_break;
-    "test_str_drop_while" >:: test_str_drop_while;
-    "test_marshal_unmarshal_int" >:: test_marshal_unmarshal_int;
-    "test_marshal_unmarshal_int8" >:: test_marshal_unmarshal_int8;
-    "test_marshal_unmarshal_int16" >:: test_marshal_unmarshal_int16;
-    "test_marshal_unmarshal_int32" >:: test_marshal_unmarshal_int32;
-    "test_marshal_unmarshal_int64" >:: test_marshal_unmarshal_int64;
-    "test_unmask" >:: test_unmask;
-  ]
+  "test_helpers"
+  >::: [
+         "test_split" >:: test_split
+       ; "test_break" >:: test_break
+       ; "test_str_drop_while" >:: test_str_drop_while
+       ; "test_marshal_unmarshal_int" >:: test_marshal_unmarshal_int
+       ; "test_marshal_unmarshal_int8" >:: test_marshal_unmarshal_int8
+       ; "test_marshal_unmarshal_int16" >:: test_marshal_unmarshal_int16
+       ; "test_marshal_unmarshal_int32" >:: test_marshal_unmarshal_int32
+       ; "test_marshal_unmarshal_int64" >:: test_marshal_unmarshal_int64
+       ; "test_unmask" >:: test_unmask
+       ]

--- a/test/test_iteratees.ml
+++ b/test/test_iteratees.ml
@@ -14,87 +14,106 @@
 
 open OUnit
 open Wslib
-
-module I = Iteratees.Iteratee(Test.StringMonad)
-module TestWsIteratee = Websockets.Wsprotocol(Test.StringMonad)
+module I = Iteratees.Iteratee (Test.StringMonad)
+module TestWsIteratee = Websockets.Wsprotocol (Test.StringMonad)
 open TestWsIteratee
 open I
 
-let get_data = function
-  | IE_done x -> Some x
-  | IE_cont _ -> None
+let get_data = function IE_done x -> Some x | IE_cont _ -> None
 
 let test_heads () =
   let res str =
-    match get_data (Test.StringMonad.getdata (enum_1chunk "test" (heads str))) with
-    | Some x -> x
-    | None -> 1234
+    match
+      get_data (Test.StringMonad.getdata (enum_1chunk "test" (heads str)))
+    with
+    | Some x ->
+        x
+    | None ->
+        1234
   in
-  assert_equal (res "t") 1;
-  assert_equal (res "te") 2;
+  assert_equal (res "t") 1 ;
+  assert_equal (res "te") 2 ;
   assert_equal (res "x") 0
 
 let test_drop () =
-  assert_equal (Test.StringMonad.getdata (enum_1chunk "test" (drop 1))) (IE_done ())
+  assert_equal
+    (Test.StringMonad.getdata (enum_1chunk "test" (drop 1)))
+    (IE_done ())
 
 let test_readn () =
   let res i =
-    match get_data (Test.StringMonad.getdata (enum_1chunk "test" (readn i))) with
-    | Some x -> x
-    | None -> "xxxxx"
+    match
+      get_data (Test.StringMonad.getdata (enum_1chunk "test" (readn i)))
+    with
+    | Some x ->
+        x
+    | None ->
+        "xxxxx"
   in
-  assert_equal (res 0) "";
-  assert_equal (res 1) "t";
-  assert_equal (res 2) "te";
+  assert_equal (res 0) "" ;
+  assert_equal (res 1) "t" ;
+  assert_equal (res 2) "te" ;
   assert_equal (res 4) "test"
 
 let test_read_int8 () =
   let res str =
-    match get_data (Test.StringMonad.getdata (enum_1chunk str (read_int8))) with
-    | Some x -> x
-    | None -> 0
+    match get_data (Test.StringMonad.getdata (enum_1chunk str read_int8)) with
+    | Some x ->
+        x
+    | None ->
+        0
   in
-  assert_equal 97 (res "a");
-  assert_equal 65 (res "A");
+  assert_equal 97 (res "a") ;
+  assert_equal 65 (res "A") ;
   assert_equal 125 (res "}")
 
 let test_peek () =
   let res str =
-    match get_data (Test.StringMonad.getdata (enum_1chunk str (peek))) with
-    | Some x -> begin match x with | Some c -> c | None -> 'g' end
-    | None -> 'g'
+    match get_data (Test.StringMonad.getdata (enum_1chunk str peek)) with
+    | Some x -> (
+      match x with Some c -> c | None -> 'g'
+    )
+    | None ->
+        'g'
   in
-  assert_equal 'a' (res "abc");
+  assert_equal 'a' (res "abc") ;
   assert_equal 'x' (res "xyz")
 
 let test_head () =
   let res str =
-    match get_data (Test.StringMonad.getdata (enum_1chunk str (head))) with
-    | Some x -> begin match x with | Some c -> c | None -> 'g' end
-    | None -> 'g'
+    match get_data (Test.StringMonad.getdata (enum_1chunk str head)) with
+    | Some x -> (
+      match x with Some c -> c | None -> 'g'
+    )
+    | None ->
+        'g'
   in
-  assert_equal 'a' (res "abc");
+  assert_equal 'a' (res "abc") ;
   assert_equal 'x' (res "xyz")
 
 let test_break () =
-  let alter = function | '\n' -> true | _ -> false in
+  let alter = function '\n' -> true | _ -> false in
   let res str =
-    match get_data (Test.StringMonad.getdata (enum_1chunk str (break alter))) with
-    | Some x -> x
-    | None -> "xxxxx"
+    match
+      get_data (Test.StringMonad.getdata (enum_1chunk str (break alter)))
+    with
+    | Some x ->
+        x
+    | None ->
+        "xxxxx"
   in
-  assert_equal "" (res "\ntest");
-  assert_equal "test" (res "test\nabc");
+  assert_equal "" (res "\ntest") ;
+  assert_equal "test" (res "test\nabc") ;
   assert_equal "abcxyz" (res "abcxyz\n")
 
 let test =
-  "test_iteratees" >:::
-  [
-    "test_heads" >:: test_heads;
-    "test_drop" >:: test_drop;
-    "test_readn" >:: test_readn;
-    "test_read_int8" >:: test_read_int8;
-    "test_peek" >:: test_peek;
-    "test_head" >:: test_head;
-    "test_break" >:: test_break;
-  ]
+  "test_iteratees"
+  >::: [
+         "test_heads" >:: test_heads
+       ; "test_drop" >:: test_drop
+       ; "test_readn" >:: test_readn
+       ; "test_read_int8" >:: test_read_int8
+       ; "test_peek" >:: test_peek
+       ; "test_head" >:: test_head
+       ; "test_break" >:: test_break
+       ]

--- a/test/test_websockets.ml
+++ b/test/test_websockets.ml
@@ -14,73 +14,99 @@
 
 open OUnit
 open Wslib
-
-module TestWsIteratee = Websockets.Wsprotocol(Test.StringMonad)
-module I = Iteratees.Iteratee(Test.StringMonad)
+module TestWsIteratee = Websockets.Wsprotocol (Test.StringMonad)
+module I = Iteratees.Iteratee (Test.StringMonad)
 open TestWsIteratee
 open I
 
 (* Unmasked text message frame *)
 let test_strings =
-  [ "\x81\x05\x48\x65\x6c\x6c\x6f"; (* contains "Hello" *)
-    "\x01\x03\x48\x65\x6c";         (* contains "Hel" *)
-    "\x80\x02\x6c\x6f";             (* contains "lo" *)
-    "\x82\x7F\x0000000000010000";   (* contains 256 bytes of binary data *)
-    "\x82\x7F\x0000000000010000"    (* contains 65536 bytes of binary data *)
+  [
+    "\x81\x05\x48\x65\x6c\x6c\x6f"
+  ; (* contains "Hello" *)
+    "\x01\x03\x48\x65\x6c"
+  ; (* contains "Hel" *)
+    "\x80\x02\x6c\x6f"
+  ; (* contains "lo" *)
+    "\x82\x7F\x0000000000010000"
+  ; (* contains 256 bytes of binary data *)
+    "\x82\x7F\x0000000000010000" (* contains 65536 bytes of binary data *)
   ]
+
 let test_old_str = "\x00Hello\xff\x00There\xff"
+
 (* A single-frame masked text message *)
-let test_mask_str = "\x81\x85\x37\xfa\x21\x3d\x7f\x9f\x4d\x51\x58" (* contains "Hello" *)
+let test_mask_str = "\x81\x85\x37\xfa\x21\x3d\x7f\x9f\x4d\x51\x58"
+
+(* contains "Hello" *)
 
 let test_wsframe () =
   let frame = wsframe (writer Test.StringMonad.strwr "foo") in
   let unframe = wsunframe (writer Test.StringMonad.strwr "bar") in
-  test_strings |> List.iter (fun str ->
-    (* Test with enum_1chunk *)
-    let x = enum_1chunk (Test.StringMonad.getstr (enum_1chunk str frame)) unframe in
-    assert_equal str (Test.StringMonad.getstr x);
-    (* Test with enum_nchunk *)
-    for i = 1 to 10 do
-      let z = enum_nchunk (Test.StringMonad.getstr (enum_nchunk str i frame)) i unframe in
-      assert_equal str (Test.StringMonad.getstr z)
-    done)
+  test_strings
+  |> List.iter (fun str ->
+         (* Test with enum_1chunk *)
+         let x =
+           enum_1chunk (Test.StringMonad.getstr (enum_1chunk str frame)) unframe
+         in
+         assert_equal str (Test.StringMonad.getstr x) ;
+         (* Test with enum_nchunk *)
+         for i = 1 to 10 do
+           let z =
+             enum_nchunk
+               (Test.StringMonad.getstr (enum_nchunk str i frame))
+               i unframe
+           in
+           assert_equal str (Test.StringMonad.getstr z)
+         done)
 
 let test_wsframe_old () =
   let frame = wsframe_old (writer Test.StringMonad.strwr "foo") in
   let unframe = wsunframe_old (writer Test.StringMonad.strwr "bar") in
-  test_strings |> List.iter (fun str ->
-    (* Test with enum_1chunk *)
-    let x = enum_1chunk (Test.StringMonad.getstr (enum_1chunk str frame)) unframe in
-    assert_equal str (Test.StringMonad.getstr x);
-    (* Test with enum_nchunk *)
-    for i = 1 to 10 do
-      let z = enum_nchunk (Test.StringMonad.getstr (enum_nchunk str i frame)) i unframe in
-      assert_equal str (Test.StringMonad.getstr z)
-    done)
+  test_strings
+  |> List.iter (fun str ->
+         (* Test with enum_1chunk *)
+         let x =
+           enum_1chunk (Test.StringMonad.getstr (enum_1chunk str frame)) unframe
+         in
+         assert_equal str (Test.StringMonad.getstr x) ;
+         (* Test with enum_nchunk *)
+         for i = 1 to 10 do
+           let z =
+             enum_nchunk
+               (Test.StringMonad.getstr (enum_nchunk str i frame))
+               i unframe
+           in
+           assert_equal str (Test.StringMonad.getstr z)
+         done)
 
 let test_wsunframe () =
   let unframe = wsunframe (writer Test.StringMonad.strwr "foo") in
   (* Test with enum_1chunk *)
-  assert_equal "Hello" (Test.StringMonad.getstr (enum_1chunk test_mask_str unframe));
+  assert_equal "Hello"
+    (Test.StringMonad.getstr (enum_1chunk test_mask_str unframe)) ;
   (* Test with enum_nchunk *)
   for i = 1 to 10 do
-    assert_equal "Hello" (Test.StringMonad.getstr (enum_nchunk test_mask_str i unframe))
+    assert_equal "Hello"
+      (Test.StringMonad.getstr (enum_nchunk test_mask_str i unframe))
   done
 
 let test_wsunframe_old () =
   let unframe = wsunframe_old (writer Test.StringMonad.strwr "foo") in
   (* Test with enum_1chunk *)
-  assert_equal "HelloThere" (Test.StringMonad.getstr (enum_1chunk test_old_str unframe));
+  assert_equal "HelloThere"
+    (Test.StringMonad.getstr (enum_1chunk test_old_str unframe)) ;
   (* Test with enum_nchunk *)
   for i = 1 to 10 do
-    assert_equal "HelloThere" (Test.StringMonad.getstr (enum_nchunk test_old_str i unframe))
+    assert_equal "HelloThere"
+      (Test.StringMonad.getstr (enum_nchunk test_old_str i unframe))
   done
 
 let test =
-  "test_websockets" >:::
-  [
-    "test_wsframe" >:: test_wsframe;
-    "test_wsunframe" >:: test_wsunframe;
-    "test_wsframe_old" >:: test_wsframe_old;
-    "test_wsunframe_old" >:: test_wsunframe_old;
-  ]
+  "test_websockets"
+  >::: [
+         "test_wsframe" >:: test_wsframe
+       ; "test_wsunframe" >:: test_wsunframe
+       ; "test_wsframe_old" >:: test_wsframe_old
+       ; "test_wsunframe_old" >:: test_wsunframe_old
+       ]

--- a/test/wsproxy_tests.ml
+++ b/test/wsproxy_tests.ml
@@ -15,12 +15,6 @@
 open OUnit
 
 let tests =
-  "tests" >:::
-  [
-    Test_helpers.test;
-    Test_iteratees.test;
-    Test_websockets.test;
-  ]
+  "tests" >::: [Test_helpers.test; Test_iteratees.test; Test_websockets.test]
 
-let () =
-  ounit2_of_ounit1 tests |> OUnit2.run_test_tt_main;
+let () = ounit2_of_ounit1 tests |> OUnit2.run_test_tt_main

--- a/wsproxy.opam
+++ b/wsproxy.opam
@@ -14,8 +14,9 @@ depends: [
   "ocaml"
   "dune" {build}
   "base64" {>= "3.1.0"}
+  "fmt"
+  "logs"
   "lwt" {>= "3.0.0"}
-  "lwt_log"
   "re"
   "uuidm"
   "ounit" {with-test}


### PR DESCRIPTION
They couldn't  be integrated before because of a possible conflict of the socket name, which now controlled by xen-api, now a socket with a different name is used to avoid the conflict. #21 

Must be merged along https://github.com/xapi-project/xen-api/pull/4180

Also formats the code using ocamlformat.